### PR TITLE
Remove return model at end of boot creating

### DIFF
--- a/app/Support/HasUuid.php
+++ b/app/Support/HasUuid.php
@@ -16,8 +16,6 @@ trait HasUuid
             }
 
             $model->uuid = Uuid::uuid4();
-
-            return $model;
         });
     }
 


### PR DESCRIPTION
Remove return $model at end of self/static::creating. If you return model there other boot creating for the model wouldn't run