### PR TITLE
Limit rss feed to posts from last month and allow tag-based filtering

### DIFF
--- a/app/App/Http/Controllers/RssController.php
+++ b/app/App/Http/Controllers/RssController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Queries\LastMonthPostsQuery;
+use Domain\Post\Models\Tag;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\Request;
+
+final class RssController
+{
+    public function feed(
+        Request $request,
+        LastMonthPostsQuery $query
+    ): Collection {
+        $tags = $request->get('tag');
+        if ($tags !== null) {
+            $tagCollection = Tag::whereIn('slug', $tags)->get();
+            $query->whereTags($tagCollection);
+        }
+
+        return $query->get();
+    }
+}

--- a/app/App/Http/Queries/LastMonthPostsQuery.php
+++ b/app/App/Http/Queries/LastMonthPostsQuery.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Queries;
+
+use Carbon\Carbon;
+use Domain\Post\Models\Post;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\Request;
+
+class LastMonthPostsQuery extends PostsQuery
+{
+    public function __construct(Request $request)
+    {
+        $query = Post::query()
+            ->whereDate('date_created', '>', Carbon::make('-1 month'));
+
+        parent::__construct($query, $request);
+    }
+
+    public function whereTags(Collection $tags): self
+    {
+        $this->query->whereIn('tag_id', $tags->pluck('id'));
+
+        return $this;
+    }
+}

--- a/config/feed.php
+++ b/config/feed.php
@@ -1,12 +1,12 @@
 <?php
 
-use App\Http\Queries\AllPostsQuery;
+use App\Http\Controllers\RssController;
 
 return [
     'feeds' => [
         'main' => [
             'items' => [
-                vsprintf('%s@%s', [AllPostsQuery::class, 'get'])
+                vsprintf('%s@%s', [RssController::class, 'feed'])
             ],
             'url' => '/rss',
             'title' => 'aggregate.stitcher.io',

--- a/database/factories/PostTagFactory.php
+++ b/database/factories/PostTagFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use Domain\Post\Models\PostTag;
+
+$factory->define(PostTag::class, function () {
+    return [
+        'id' => faker()->randomNumber(),
+        'post_id' => faker()->randomNumber(),
+        'tag_id' => faker()->randomNumber(),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ];
+});

--- a/tests/App/Http/Queries/LastMonthPostQueryTest.php
+++ b/tests/App/Http/Queries/LastMonthPostQueryTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Domain\Post\Models;
+
+use App\Http\Queries\LastMonthPostsQuery;
+use Carbon\Carbon;
+use Domain\Post\Models\Post;
+use Domain\Post\Models\PostTag;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class LastMonthPostQueryTest extends TestCase
+{
+    /** @test */
+    public function shows_posts_for_last_month(): void
+    {
+        factory(Post::class, 2)->create([
+            'date_created' => Carbon::make('-1 week'),
+        ]);
+        factory(Post::class)->create([
+            'date_created' => Carbon::make('-2 months'),
+        ]);
+
+        $query = new LastMonthPostsQuery(new Request());
+
+        $this->assertEquals(2, $query->count());
+    }
+
+    /** @test */
+    public function can_filter_on_tags(): void
+    {
+        $this->createPostWithTagId(1);
+        $this->createPostWithTagId(1);
+        $this->createPostWithTagId(2);
+
+        $query = new LastMonthPostsQuery(new Request());
+        $topics = new Collection([['id' => 1]]);
+        $query->whereTags($topics);
+
+        $this->assertEquals(2, $query->count());
+    }
+
+    private function createPostWithTagId(int $tagId): void
+    {
+        $somePost = factory(Post::class)->create([
+            'date_created' => Carbon::make('-1 week'),
+        ]);
+        factory(PostTag::class)->create([
+            'tag_id' => $tagId,
+            'post_id' => $somePost->id,
+        ]);
+    }
+}

--- a/tests/Domain/Post/Models/PostTest.php
+++ b/tests/Domain/Post/Models/PostTest.php
@@ -159,7 +159,7 @@ class PostTest extends TestCase
     }
 
     /** @test */
-    public function can_be_converted_to_feed_item()
+    public function can_be_converted_to_feed_item(): void
     {
         /** @var \Domain\Source\Models\Source $source */
         $source = factory(Source::class)->create();


### PR DESCRIPTION
Implementation of issue #80, which limits the rss feed to posts from last month only.
Additionally allow filtering based on one or multiple tags.