### PR TITLE
Fix sqlite database config

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -35,7 +35,7 @@ return [
 
         'sqlite' => [
             'driver' => 'sqlite',
-            'database' => env('DB_DATABASE', database_path('database.sqlite')),
+            'database' => database_path(env('DB_DATABASE', 'database.sqlite')),
             'prefix' => '',
         ],
 


### PR DESCRIPTION
When using SQLite, the `php artisan playbook:run PostsPlaybook` command will create a sqlite database called `aggregate` in the project root. This will result in the lovely error `Database (aggregate) does not exist.` when accessing the index page due to `realpath($config['database']);` returning false in the SQLiteConnector.

By wrapping the `database` config value for the sqlite config with `database_path()`, the SQLiteConnector gets an actual path that it can resolve, instead of just the string `aggregate`.