### PR TITLE
Don't add "noreferrer" to external links

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -69,7 +69,7 @@
                             href
                         ="{{ $post->url }}"
                         target="_blank"
-                        rel="noopener noreferrer"
+                        rel="noopener"
                         class="
                         block px-12 p-4
                         {{ $post->isPending() ? 'bg-gray-200' : '' }}


### PR DESCRIPTION
Allow marking the aggregate page as a referrer in traffic analysis tools.

Fixes #139